### PR TITLE
refactor: :recycle: 경로를 상수로 관리하도록 수정

### DIFF
--- a/src/pages/home/index.page.tsx
+++ b/src/pages/home/index.page.tsx
@@ -8,6 +8,7 @@ import { NextPage } from 'next';
 import * as S from './home.styles';
 
 import splashLottie from '@src/assets/lotti/splash.json';
+import { ROUTE } from '@src/shared/constants/route';
 
 const Home: NextPage = () => {
   const lottieRef = useRef<HTMLDivElement>(null);
@@ -29,7 +30,7 @@ const Home: NextPage = () => {
   }, []);
 
   const handleLoginBtnClick: MouseEventHandler<HTMLButtonElement> = () => {
-    router.push('/signin');
+    router.push(ROUTE.SIGN_IN);
   };
 
   return (

--- a/src/pages/signin/complete/index.page.tsx
+++ b/src/pages/signin/complete/index.page.tsx
@@ -7,6 +7,7 @@ import * as S from './complete.styles';
 
 import loginLottie from '@src/assets/lotti/login.json';
 import { Button } from '@src/shared/components';
+import { ROUTE } from '@src/shared/constants/route';
 
 const SignInComplete: NextPage = () => {
   const lottieRef = useRef<HTMLDivElement>(null);
@@ -28,7 +29,7 @@ const SignInComplete: NextPage = () => {
   }, []);
 
   const handleOnStartBtnClick = () => {
-    router.push('/');
+    router.push(ROUTE.HOME);
   };
 
   return (

--- a/src/pages/signin/index.page.tsx
+++ b/src/pages/signin/index.page.tsx
@@ -6,6 +6,7 @@ import * as S from './signin.styles';
 
 import useSigninForm, { SigninFormType } from '@src/features/auth/hooks/useSigninForm';
 import { Button, TextField } from '@src/shared/components';
+import { ROUTE } from '@src/shared/constants/route';
 
 const SignIn: NextPage = () => {
   const { control, formState, handleSubmit } = useSigninForm();
@@ -14,7 +15,7 @@ const SignIn: NextPage = () => {
 
   const onSubmit: SubmitHandler<SigninFormType> = (values) => {
     alert(JSON.stringify(values, null, 2));
-    router.push('/signin/complete');
+    router.push(ROUTE.SIGN_IN_COMPLETE);
   };
 
   return (

--- a/src/pages/signup/complete/index.page.tsx
+++ b/src/pages/signup/complete/index.page.tsx
@@ -7,6 +7,7 @@ import * as S from './complete.styles';
 
 import signupLottie from '@src/assets/lotti/signup.json';
 import { Button } from '@src/shared/components';
+import { ROUTE } from '@src/shared/constants/route';
 
 const SignUpComplete: NextPage = () => {
   const lottieRef = useRef<HTMLDivElement>(null);
@@ -28,8 +29,7 @@ const SignUpComplete: NextPage = () => {
   }, []);
 
   const handleOnStartBtnClick = () => {
-    //push home
-    router.push('/');
+    router.push(ROUTE.HOME);
   };
 
   return (

--- a/src/pages/signup/index.page.tsx
+++ b/src/pages/signup/index.page.tsx
@@ -7,6 +7,7 @@ import * as S from './signup.styles';
 
 import useSignupForm, { SignUpFormType } from '@src/features/auth/hooks/useSignupForm';
 import { Button, Stepper, TextField } from '@src/shared/components';
+import { ROUTE } from '@src/shared/constants/route';
 
 const SignUp: NextPage = () => {
   const [activeIndex, setActiveIndex] = useState(0);
@@ -28,7 +29,7 @@ const SignUp: NextPage = () => {
 
   const onSubmit: SubmitHandler<SignUpFormType> = (values) => {
     alert(JSON.stringify(values, null, 2));
-    router.push('/signup/complete');
+    router.push(ROUTE.SIGN_UP_COMPLETE);
   };
 
   //TODO: 쓰로틀로 아이디 중복체크

--- a/src/shared/constants/route.ts
+++ b/src/shared/constants/route.ts
@@ -1,0 +1,7 @@
+export const ROUTE = Object.freeze({
+  HOME: '/',
+  SIGN_IN: '/signin',
+  SIGN_IN_COMPLETE: '/signin/complete',
+  SIGN_UP: '/signup',
+  SIGN_UP_COMPLETE: '/signup/complete',
+});


### PR DESCRIPTION
## 📍 주요 변경사항

<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

경로를 상수로 관리하도록 수정했습니다1

아무래도 룸 목록에 해당하는 경로가 서비스의 홈 화면이므로 '/', home이 되어야 할 것 같고,
시작화면은 '/home'이 아닌 앱을 막 설치한 사용자를 반길때만 사용되는 페이지이므로 '/welcome'이라고 하는 것은 어떤가요??


## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

## 💡 중점적으로 봐주었으면 하는 부분

<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->
