### PR TITLE
feat: :sparkles: add nativeBridge, nativeMessageReceiver

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -40,4 +40,4 @@ jobs:
         run: yarn lint
 
       - name: TS check
-        run: yarn tsc
+        run: yarn type-check

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ tsconfig.tsbuildinfo
 
 #misc
 .DS_Store
+

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,7 @@
+declare global {
+  interface Window {
+    ReactNativeWebView: {
+      postMessage: (message: string) => void;
+    };
+  }
+}

--- a/global.d.ts
+++ b/global.d.ts
@@ -5,3 +5,5 @@ declare global {
     };
   }
 }
+
+export {};

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 });
@@ -10,7 +11,14 @@ const nextConfig = {
   reactStrictMode: false,
   pageExtensions: ['page.tsx', 'page.ts'],
   images: {
-    domains:['memochat-develop.s3.ap-northeast-2.amazonaws.com']
+    domains: ['memochat-develop.s3.ap-northeast-2.amazonaws.com'],
+  },
+  typescript: {
+    tsconfigPath: path.resolve(__dirname, 'tsconfig.json'),
+    ignoreBuildErrors: true,
+  },
+  eslint: {
+    ignoreDuringBuilds: true,
   },
   /**@param {import("webpack").Configuration} config */
   webpack(config) {
@@ -33,7 +41,7 @@ const nextConfig = {
         destination: '/rooms',
         permanent: true,
       },
-    ]
+    ];
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint": "next lint",
     "prettier": "prettier --write **/*.{ts,tsx}",
     "analyze": "ANALYZE=true yarn build",
-    "tsc": "tsc",
+    "type-check": "tsc --noEmit",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "deploy-storybook": "storybook-to-ghpages",

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -1,4 +1,5 @@
 import { ThemeProvider } from '@emotion/react';
+import '@src/shared/configs/i18n';
 import { Hydrate, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import type { AppProps } from 'next/app';
@@ -16,8 +17,6 @@ import { ModalReducerContextProvider } from '@src/shared/contexts/ModalReducerCo
 import GlobalStyle from '@src/shared/styles/GlobalStyle';
 import { lightTheme } from '@src/shared/styles/themes';
 import { NextPageWithLayout } from '@src/shared/types/next';
-
-import '@src/shared/configs/i18n';
 
 type AppPropsWithLayout = AppProps & {
   Component: NextPageWithLayout;

--- a/src/shared/components/NativeBridgeProvider/NativeBridgeProvider.tsx
+++ b/src/shared/components/NativeBridgeProvider/NativeBridgeProvider.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 
 import { NativeBridgeProviderProps } from '@src/shared/components/NativeBridgeProvider/types';
 import NativeBridge from '@src/shared/configs/nativeBridge';
-import NativeMsgReceiver, {
+import NativeMessageReceiver, {
   MemochatNativeMessage,
 } from '@src/shared/configs/nativeMessageReceiver';
 
@@ -17,16 +17,16 @@ const NativeBridgeProvider = (props: NativeBridgeProviderProps) => {
   useEffect(() => {
     const handleMessageReceive = (e: Event) => {
       const event = e as MessageEvent;
-      const msg = JSON.parse(event.data) as MemochatNativeMessage;
-      const nativeMsgReceiver = new NativeMsgReceiver();
+      const message = JSON.parse(event.data) as MemochatNativeMessage;
+      const nativeMessageReceiver = new NativeMessageReceiver();
 
-      switch (msg.action) {
+      switch (message.action) {
         case 'back': {
-          nativeMsgReceiver.back(msg);
+          nativeMessageReceiver.back(message);
           return;
         }
         default: {
-          console.log(msg);
+          console.log(message);
         }
       }
     };

--- a/src/shared/components/NativeBridgeProvider/NativeBridgeProvider.tsx
+++ b/src/shared/components/NativeBridgeProvider/NativeBridgeProvider.tsx
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+
+import { NativeBridgeProviderProps } from '@src/shared/components/NativeBridgeProvider/types';
+import NativeBridge from '@src/shared/configs/nativeBridge';
+import NativeMsgReceiver, {
+  MemochatNativeMessage,
+} from '@src/shared/configs/nativeMessageReceiver';
+
+const NativeBridgeProvider = (props: NativeBridgeProviderProps) => {
+  const { children } = props;
+
+  useEffect(() => {
+    const nativeBridge = new NativeBridge();
+    nativeBridge.test();
+  }, []);
+
+  useEffect(() => {
+    const handleMessageReceive = (e: Event) => {
+      const event = e as MessageEvent;
+      const msg = JSON.parse(event.data) as MemochatNativeMessage;
+      const nativeMsgReceiver = new NativeMsgReceiver();
+
+      switch (msg.action) {
+        case 'back': {
+          nativeMsgReceiver.back(msg);
+          return;
+        }
+        default: {
+          console.log(msg);
+        }
+      }
+    };
+
+    document.addEventListener('message', handleMessageReceive);
+    return () => {
+      document.removeEventListener('message', handleMessageReceive);
+    };
+  }, []);
+  return <>{children}</>;
+};
+
+export default NativeBridgeProvider;

--- a/src/shared/components/NativeBridgeProvider/index.ts
+++ b/src/shared/components/NativeBridgeProvider/index.ts
@@ -1,0 +1,1 @@
+export { default as NativeBridgeProvider } from './NativeBridgeProvider';

--- a/src/shared/components/NativeBridgeProvider/types.ts
+++ b/src/shared/components/NativeBridgeProvider/types.ts
@@ -1,0 +1,5 @@
+import { ReactNode } from 'react';
+
+export type NativeBridgeProviderProps = {
+  children: ReactNode;
+};

--- a/src/shared/configs/nativeBridge/index.ts
+++ b/src/shared/configs/nativeBridge/index.ts
@@ -1,0 +1,24 @@
+export interface MemochatWebViewMessage {
+  action: 'test';
+  data?: Record<string, unknown>;
+  callbackId?: string;
+}
+
+class NativeBridge {
+  static instance: NativeBridge;
+
+  constructor() {
+    if (NativeBridge.instance) {
+      return NativeBridge.instance;
+    }
+    NativeBridge.instance = this;
+    return NativeBridge.instance;
+  }
+
+  test() {
+    const msg: MemochatWebViewMessage = { action: 'test' };
+    window.ReactNativeWebView.postMessage(JSON.stringify(msg));
+  }
+}
+
+export default NativeBridge;

--- a/src/shared/configs/nativeBridge/index.ts
+++ b/src/shared/configs/nativeBridge/index.ts
@@ -16,8 +16,8 @@ class NativeBridge {
   }
 
   test() {
-    const msg: MemochatWebViewMessage = { action: 'test' };
-    window.ReactNativeWebView.postMessage(JSON.stringify(msg));
+    const message: MemochatWebViewMessage = { action: 'test' };
+    window.ReactNativeWebView.postMessage(JSON.stringify(message));
   }
 }
 

--- a/src/shared/configs/nativeMessageReceiver/index.ts
+++ b/src/shared/configs/nativeMessageReceiver/index.ts
@@ -6,21 +6,20 @@ export interface MemochatNativeMessage {
   callbackId?: string;
 }
 
-class NativeMsgReceiver {
-  static instance: NativeMsgReceiver;
+class NativeMessageReceiver {
+  static instance: NativeMessageReceiver;
 
   constructor() {
-    if (!NativeMsgReceiver.instance) {
-      NativeMsgReceiver.instance = this;
-      return NativeMsgReceiver.instance;
+    if (!NativeMessageReceiver.instance) {
+      NativeMessageReceiver.instance = this;
+      return NativeMessageReceiver.instance;
     }
-    return NativeMsgReceiver.instance;
+    return NativeMessageReceiver.instance;
   }
 
-  back(msg: MemochatNativeMessage) {
-    alert(msg.action);
+  back(message: MemochatNativeMessage) {
     Router.back();
   }
 }
 
-export default NativeMsgReceiver;
+export default NativeMessageReceiver;

--- a/src/shared/configs/nativeMessageReceiver/index.ts
+++ b/src/shared/configs/nativeMessageReceiver/index.ts
@@ -1,0 +1,26 @@
+import Router from 'next/router';
+
+export interface MemochatNativeMessage {
+  action: 'back';
+  data?: Record<string, unknown>;
+  callbackId?: string;
+}
+
+class NativeMsgReceiver {
+  static instance: NativeMsgReceiver;
+
+  constructor() {
+    if (!NativeMsgReceiver.instance) {
+      NativeMsgReceiver.instance = this;
+      return NativeMsgReceiver.instance;
+    }
+    return NativeMsgReceiver.instance;
+  }
+
+  back(msg: MemochatNativeMessage) {
+    alert(msg.action);
+    Router.back();
+  }
+}
+
+export default NativeMsgReceiver;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,6 @@
     "incremental": true
   },
   "extends": "./tsconfig.paths.json",
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "global.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules", "src/scripts"]
 }


### PR DESCRIPTION
## 📍 주요 변경사항
- native에 메시지를 보내는 싱글턴 nativeBridge 클래스를 구현했습니다.
- native의 메시지를 받는 싱글턴 nativevMessageReceiver클래스를 구현했습니다.

메시지의 인터페이스는 다음과 같이 정의했습니다.
{
  action: string // 넘어오는  action값 필요한 action들을 union으로 정의하면 좋을것 같습니다.
  callbackId: string //메시지의 응답을 받을때 사용하는 callbackId값
  data : JSON string //넘겨줄 데이터를 담는 필드
}

예제를 추가했으니 한번 확인해주시면 좋을것 같습니다.
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

## 💡 중점적으로 봐주었으면 하는 부분

<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->
