### PR TITLE
feat:  ios에서 하단 fixed input 동작 개선

### DIFF
--- a/src/features/room/components/RoomMemoForm/RoomMemoForm.tsx
+++ b/src/features/room/components/RoomMemoForm/RoomMemoForm.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, MouseEventHandler } from 'react';
+import { ChangeEvent, forwardRef, LegacyRef, MouseEventHandler } from 'react';
 
 import * as S from './RoomMemoForm.styles';
 import { RoomMemoFormProps } from './RoomMemoForm.types';
@@ -8,77 +8,80 @@ import { Icon } from '@src/shared/components';
 
 // TODO: alert -> 커스텀 alert로 변경
 // TODO: 앨범, 카메라 native 권한 요청
-const RoomMemoForm = ({ showSelectedRoom, selectedRoom }: RoomMemoFormProps) => {
-  const {
-    register,
-    setValue,
-    handleSubmit,
-    formState: { isDirty },
-  } = useRoomMemoForm();
+const RoomMemoForm = forwardRef(
+  ({ showSelectedRoom, selectedRoom }: RoomMemoFormProps, ref: LegacyRef<HTMLFormElement>) => {
+    const {
+      register,
+      setValue,
+      handleSubmit,
+      formState: { isDirty },
+    } = useRoomMemoForm();
 
-  const autoGrow = (e: ChangeEvent<HTMLTextAreaElement>) => {
-    e.currentTarget.style.height = 'auto';
-    e.currentTarget.style.height = `${64 + Math.round(e.currentTarget.scrollHeight - 64)}px`;
-  };
+    const autoGrow = (e: ChangeEvent<HTMLTextAreaElement>) => {
+      e.currentTarget.style.height = 'auto';
+      e.currentTarget.style.height = `${64 + Math.round(e.currentTarget.scrollHeight - 64)}px`;
+    };
 
-  const handleAlbumClick: MouseEventHandler<HTMLButtonElement> = () => {
-    if (!selectedRoom) {
-      alert('채팅방을 선택해주세요.');
-      return;
-    }
+    const handleAlbumClick: MouseEventHandler<HTMLButtonElement> = () => {
+      if (!selectedRoom) {
+        alert('채팅방을 선택해주세요.');
+        return;
+      }
 
-    alert('앨범 클릭');
-    setValue('images', []);
-  };
+      alert('앨범 클릭');
+      setValue('images', []);
+    };
 
-  const handleCameraClick: MouseEventHandler<HTMLButtonElement> = () => {
-    if (!selectedRoom) {
-      alert('채팅방을 선택해주세요.');
-      return;
-    }
+    const handleCameraClick: MouseEventHandler<HTMLButtonElement> = () => {
+      if (!selectedRoom) {
+        alert('채팅방을 선택해주세요.');
+        return;
+      }
 
-    alert('카메라 클릭');
-  };
+      alert('카메라 클릭');
+    };
 
-  const handleTextAreaWrapperClick = () => {
-    if (!selectedRoom) {
-      alert('채팅방을 선택해주세요.');
-    }
-  };
+    const handleTextAreaWrapperClick = () => {
+      if (!selectedRoom) {
+        alert('채팅방을 선택해주세요.');
+      }
+    };
 
-  const onSubmit = (v: RoomMemoFormType) => {
-    alert(JSON.stringify(v));
-  };
+    const onSubmit = (v: RoomMemoFormType) => {
+      alert(JSON.stringify(v));
+    };
 
-  return (
-    <S.Form onSubmit={handleSubmit((v) => onSubmit(v as RoomMemoFormType))}>
-      {showSelectedRoom && selectedRoom && (
-        <S.SelectedRoomName>{selectedRoom.name}</S.SelectedRoomName>
-      )}
-      <S.TextAreaWrapper onClick={handleTextAreaWrapperClick}>
-        {showSelectedRoom && selectedRoom && <Icon name="Reply" size={20} color="gray4" />}
-        <S.Textarea
-          {...register('memo', { onChange: autoGrow, disabled: !selectedRoom })}
-          placeholder={selectedRoom ? '메모를 입력하세요.' : '채팅방 선택 후 메모작성.'}
-        />
-      </S.TextAreaWrapper>
-      <S.ToolBox>
-        <S.ToolBoxIconBox>
-          <button type="button" onClick={handleAlbumClick} aria-label="앨범">
-            <Icon name="Album" size={32} />
-          </button>
-          <button type="button" onClick={handleCameraClick} aria-label="카메라">
-            <Icon name="Camera" size={32} />
-          </button>
-        </S.ToolBoxIconBox>
-        {isDirty && (
-          <S.SubmitBtn type="submit">
-            <Icon name="Send" size={32} />
-          </S.SubmitBtn>
+    return (
+      <S.Form ref={ref} onSubmit={handleSubmit((v) => onSubmit(v as RoomMemoFormType))}>
+        {showSelectedRoom && selectedRoom && (
+          <S.SelectedRoomName>{selectedRoom.name}</S.SelectedRoomName>
         )}
-      </S.ToolBox>
-    </S.Form>
-  );
-};
+        <S.TextAreaWrapper onClick={handleTextAreaWrapperClick}>
+          {showSelectedRoom && selectedRoom && <Icon name="Reply" size={20} color="gray4" />}
+          <S.Textarea
+            {...register('memo', { onChange: autoGrow, disabled: !selectedRoom })}
+            placeholder={selectedRoom ? '메모를 입력하세요.' : '채팅방 선택 후 메모작성.'}
+          />
+        </S.TextAreaWrapper>
+        <S.ToolBox>
+          <S.ToolBoxIconBox>
+            <button type="button" onClick={handleAlbumClick} aria-label="앨범">
+              <Icon name="Album" size={32} />
+            </button>
+            <button type="button" onClick={handleCameraClick} aria-label="카메라">
+              <Icon name="Camera" size={32} />
+            </button>
+          </S.ToolBoxIconBox>
+          {isDirty && (
+            <S.SubmitBtn type="submit">
+              <Icon name="Send" size={32} />
+            </S.SubmitBtn>
+          )}
+        </S.ToolBox>
+      </S.Form>
+    );
+  },
+);
+RoomMemoForm.displayName = 'RoomMemoForm';
 
 export default RoomMemoForm;

--- a/src/pages/_document.page.tsx
+++ b/src/pages/_document.page.tsx
@@ -15,6 +15,7 @@ class MyDocument extends Document {
         <body>
           <Main />
           <div id="bottom-sheet" />
+          <div id="make-scrollable" />
           <NextScript />
         </body>
       </Html>

--- a/src/pages/rooms/index.page.tsx
+++ b/src/pages/rooms/index.page.tsx
@@ -52,20 +52,15 @@ const RoomList = () => {
   const listWrapperRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    if (os !== 'ios' || !listWrapperRef.current) return;
     // ios인 경우 스크롤 시 input이 키보드 아래로 내려가므로 input의 focus를 해제하여 이 현상을 방지한다.
-    if (os === 'ios') {
-      const listWrapper = listWrapperRef.current;
-      if (listWrapper) {
-        const onTouchMove = () => {
-          (document.activeElement as HTMLInputElement).blur();
-        };
-
-        listWrapper.addEventListener('touchmove', onTouchMove);
-
-        return () => listWrapper.removeEventListener('touchmove', onTouchMove);
-      }
-    }
-  }, []);
+    const onTouchMove = () => {
+      (document.activeElement as HTMLInputElement).blur();
+    };
+    const listWrapper = listWrapperRef.current;
+    listWrapper.addEventListener('touchmove', onTouchMove);
+    return () => listWrapper.removeEventListener('touchmove', onTouchMove);
+  }, [os]);
 
   const handleRoomSelect = (room: MemoRoom) => {
     const isSelected = room.id === selectedRoom?.id;

--- a/src/pages/rooms/index.page.tsx
+++ b/src/pages/rooms/index.page.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
@@ -20,8 +20,13 @@ import { getMemoRoomCategories } from '@src/features/room/api/useMemoRoomCategor
 import { GetServerSidePropsWithState } from '@src/shared/types/next';
 import { memoRoomCategoryKeys, memoRoomKeys } from '@src/shared/utils/queryKeys';
 import { queryClient } from '@src/shared/configs/react-query';
+import KeyboardFloatingLayout from '@src/shared/components/KeyboardFloatingLayout';
+import useElementDimension from '@src/shared/hooks/useDimension';
+import { getOS } from '@src/shared/utils/getOS';
 
 const RoomList = () => {
+  const os = getOS();
+
   const router = useRouter();
   const { confirm } = useConfirm();
 
@@ -33,11 +38,34 @@ const RoomList = () => {
   const [isCreateRoomDialogOpen, setIsCreateRoomDialogOpen] = useState(false);
   const [isUpdateRoomDialogOpen, setIsUpdateRoomDialogOpen] = useState(false);
 
+  const {
+    ref: memoFormRef,
+    dimension: { height: memoFormHeight },
+  } = useElementDimension<HTMLFormElement>();
+
   const { mutate: deleteMemoRoom } = useDeleteMemoRoomMutation({
     onSuccess: () => {
       queryClient.invalidateQueries(memoRoomKeys.list());
     },
   });
+
+  const listWrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // ios인 경우 스크롤 시 input이 키보드 아래로 내려가므로 input의 focus를 해제하여 이 현상을 방지한다.
+    if (os === 'ios') {
+      const listWrapper = listWrapperRef.current;
+      if (listWrapper) {
+        const onTouchMove = () => {
+          (document.activeElement as HTMLInputElement).blur();
+        };
+
+        listWrapper.addEventListener('touchmove', onTouchMove);
+
+        return () => listWrapper.removeEventListener('touchmove', onTouchMove);
+      }
+    }
+  }, []);
 
   const handleRoomSelect = (room: MemoRoom) => {
     const isSelected = room.id === selectedRoom?.id;
@@ -89,10 +117,10 @@ const RoomList = () => {
           </a>
         </Link>
       </S.Header>
-      <S.Wrapper>
+      <S.ListWrapper ref={listWrapperRef} paddingBottom={memoFormHeight}>
         {isLoading && <>{/* TODO: 로딩시 스피너 띄우기 */}</>}
         {!isLoading && !rooms?.length && <RoomListEmpty />}
-        {!isLoading && rooms.length > 0 && (
+        {!isLoading && rooms?.length > 0 && (
           <SwipeableList fullSwipe={false} type={ListType.IOS}>
             {rooms.map((room) => (
               <RoomListItem
@@ -110,11 +138,11 @@ const RoomList = () => {
             ))}
           </SwipeableList>
         )}
-      </S.Wrapper>
-      <S.FloatingBottomLayout>
+      </S.ListWrapper>
+      <KeyboardFloatingLayout>
         <S.RoomCreateButton onClick={handleRoomCreateClick} />
-        <RoomMemoForm selectedRoom={selectedRoom} showSelectedRoom />
-      </S.FloatingBottomLayout>
+        <RoomMemoForm ref={memoFormRef} selectedRoom={selectedRoom} showSelectedRoom />
+      </KeyboardFloatingLayout>
       <UpsertRoomDialog
         type="create"
         open={isCreateRoomDialogOpen}

--- a/src/pages/rooms/rooms.styles.ts
+++ b/src/pages/rooms/rooms.styles.ts
@@ -4,9 +4,9 @@ import RoomCreateButtonComponent from '@src/features/room/components/RoomCreateB
 
 const HEADER_HEIGHT = 51;
 
-export const Wrapper = styled.div`
+export const ListWrapper = styled.div<{ paddingBottom: number }>`
   min-height: 100vh;
-  padding: ${HEADER_HEIGHT + 12}px 0 calc(env(safe-area-inset-bottom, 0) + 120px);
+  ${(p) => `padding: ${HEADER_HEIGHT + 12}px 0 ${p.paddingBottom}px;`}
   -webkit-overflow-scrolling: touch;
 `;
 
@@ -32,13 +32,6 @@ export const ProfileImg = styled.img`
   overflow: hidden;
 
   background-color: ${(p) => p.theme.color.gray6};
-`;
-
-export const FloatingBottomLayout = styled.div`
-  position: fixed;
-  left: 0;
-  bottom: 0;
-  width: 100%;
 `;
 
 export const RoomCreateButton = styled(RoomCreateButtonComponent)`

--- a/src/shared/components/KeyboardFloatingLayout/KeyboardFloatingLayout.stories.tsx
+++ b/src/shared/components/KeyboardFloatingLayout/KeyboardFloatingLayout.stories.tsx
@@ -1,0 +1,11 @@
+import { ComponentMeta, StoryObj } from '@storybook/react';
+
+import KeyboardFloatingLayout from '.';
+
+export default {
+  component: KeyboardFloatingLayout,
+  args: {},
+  argTypes: {},
+} as ComponentMeta<typeof KeyboardFloatingLayout>;
+
+export const Default: StoryObj<typeof KeyboardFloatingLayout> = {};

--- a/src/shared/components/KeyboardFloatingLayout/KeyboardFloatingLayout.styles.ts
+++ b/src/shared/components/KeyboardFloatingLayout/KeyboardFloatingLayout.styles.ts
@@ -1,0 +1,9 @@
+import styled from '@emotion/styled';
+
+export const Wrapper = styled.div`
+  position: fixed;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  transition: transform 0.3s;
+`;

--- a/src/shared/components/KeyboardFloatingLayout/KeyboardFloatingLayout.tsx
+++ b/src/shared/components/KeyboardFloatingLayout/KeyboardFloatingLayout.tsx
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+
+import { KeyboardFloatingLayoutProps } from './KeyboardFloatingLayout.types';
+import * as S from './KeyboardFloatingLayout.styles';
+
+import useVisualViewportDimension from '@src/shared/hooks/useVisualViewportDimension';
+import { getOS } from '@src/shared/utils/getOS';
+
+const KeyboardFloatingLayout = ({ children }: KeyboardFloatingLayoutProps) => {
+  const os = getOS();
+
+  const { height: visualViewportHeight } = useVisualViewportDimension(os === 'ios');
+
+  useEffect(() => {
+    if (os === 'ios') {
+      // 키보드 변경시 입력창이 가려지는 문제 수정
+      if (visualViewportHeight < window.outerHeight) {
+        const scrollHeight = window.document.scrollingElement.scrollHeight;
+        const scrollTop = scrollHeight - window.visualViewport.height;
+
+        window.scrollTo({ top: scrollTop });
+      }
+    }
+  }, [os, visualViewportHeight]);
+
+  return <S.Wrapper>{children}</S.Wrapper>;
+};
+
+export default KeyboardFloatingLayout;

--- a/src/shared/components/KeyboardFloatingLayout/KeyboardFloatingLayout.tsx
+++ b/src/shared/components/KeyboardFloatingLayout/KeyboardFloatingLayout.tsx
@@ -12,14 +12,13 @@ const KeyboardFloatingLayout = ({ children }: KeyboardFloatingLayoutProps) => {
   const { height: visualViewportHeight } = useVisualViewportDimension(os === 'ios');
 
   useEffect(() => {
-    if (os === 'ios') {
-      // 키보드 변경시 입력창이 가려지는 문제 수정
-      if (visualViewportHeight < window.outerHeight) {
-        const scrollHeight = window.document.scrollingElement.scrollHeight;
-        const scrollTop = scrollHeight - window.visualViewport.height;
+    if (os !== 'ios') return;
+    // 키보드 변경시 입력창이 가려지는 문제 수정
+    if (visualViewportHeight < window.outerHeight) {
+      const scrollHeight = window.document.scrollingElement.scrollHeight;
+      const scrollTop = scrollHeight - window.visualViewport.height;
 
-        window.scrollTo({ top: scrollTop });
-      }
+      window.scrollTo({ top: scrollTop });
     }
   }, [os, visualViewportHeight]);
 

--- a/src/shared/components/KeyboardFloatingLayout/KeyboardFloatingLayout.types.ts
+++ b/src/shared/components/KeyboardFloatingLayout/KeyboardFloatingLayout.types.ts
@@ -1,0 +1,3 @@
+export interface KeyboardFloatingLayoutProps {
+  children: React.ReactNode;
+}

--- a/src/shared/components/KeyboardFloatingLayout/index.ts
+++ b/src/shared/components/KeyboardFloatingLayout/index.ts
@@ -1,0 +1,2 @@
+export { default } from './KeyboardFloatingLayout';
+export type { KeyboardFloatingLayoutProps } from './KeyboardFloatingLayout.types';

--- a/src/shared/hooks/useDimension.ts
+++ b/src/shared/hooks/useDimension.ts
@@ -1,5 +1,5 @@
 import { useRef, useState, useEffect, RefObject } from 'react';
-import { debounce as _debounce } from 'lodash';
+import { debounce as _debounce } from 'lodash-es';
 
 const DEBOUNCE_WAIT_TIME = 300;
 

--- a/src/shared/hooks/useDimension.ts
+++ b/src/shared/hooks/useDimension.ts
@@ -1,0 +1,55 @@
+import { useRef, useState, useEffect, RefObject, useCallback } from 'react';
+import { debounce as _debounce } from 'lodash';
+
+const DEBOUNCE_WAIT_TIME = 300;
+
+type Dimension = {
+  width: number;
+  height: number;
+};
+
+interface useElementSizeOptions {
+  debounce?: boolean;
+  enabled?: boolean;
+}
+
+const useElementDimension = <T extends HTMLElement>({
+  debounce,
+  enabled = true,
+}: useElementSizeOptions = {}): {
+  ref: RefObject<T>;
+  dimension: Dimension;
+} => {
+  const ref = useRef<T>(null);
+  const [dimension, setDimension] = useState<Dimension>({
+    width: 0,
+    height: 0,
+  });
+
+  useEffect(() => {
+    if (enabled) {
+      if (!ref.current) return;
+
+      const resizeHandler: ResizeObserverCallback = (entries) => {
+        const entry = entries[0];
+        if (entry.contentRect) {
+          setDimension({
+            width: entry.contentRect.width,
+            height: entry.contentRect.height,
+          });
+        }
+      };
+
+      const debouncedResizeHandler = _debounce(resizeHandler, DEBOUNCE_WAIT_TIME);
+      const resizeObserver = new ResizeObserver(debounce ? debouncedResizeHandler : resizeHandler);
+
+      resizeObserver.observe(ref.current);
+
+      return () => resizeObserver.disconnect();
+    }
+  }, [ref, debounce, enabled]);
+
+  return { ref, dimension };
+};
+
+export default useElementDimension;

--- a/src/shared/hooks/useDimension.ts
+++ b/src/shared/hooks/useDimension.ts
@@ -27,26 +27,24 @@ const useElementDimension = <T extends HTMLElement>({
   });
 
   useEffect(() => {
-    if (enabled) {
-      if (!ref.current) return;
+    if (!enabled || !ref.current) return;
 
-      const resizeHandler: ResizeObserverCallback = (entries) => {
-        const entry = entries[0];
-        if (entry.contentRect) {
-          setDimension({
-            width: entry.contentRect.width,
-            height: entry.contentRect.height,
-          });
-        }
-      };
+    const resizeHandler: ResizeObserverCallback = (entries) => {
+      const entry = entries[0];
+      if (entry.contentRect) {
+        setDimension({
+          width: entry.contentRect.width,
+          height: entry.contentRect.height,
+        });
+      }
+    };
 
-      const debouncedResizeHandler = _debounce(resizeHandler, DEBOUNCE_WAIT_TIME);
-      const resizeObserver = new ResizeObserver(debounce ? debouncedResizeHandler : resizeHandler);
+    const debouncedResizeHandler = _debounce(resizeHandler, DEBOUNCE_WAIT_TIME);
+    const resizeObserver = new ResizeObserver(debounce ? debouncedResizeHandler : resizeHandler);
 
-      resizeObserver.observe(ref.current);
+    resizeObserver.observe(ref.current);
 
-      return () => resizeObserver.disconnect();
-    }
+    return () => resizeObserver.disconnect();
   }, [ref, debounce, enabled]);
 
   return { ref, dimension };

--- a/src/shared/hooks/useDimension.ts
+++ b/src/shared/hooks/useDimension.ts
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect, RefObject, useCallback } from 'react';
+import { useRef, useState, useEffect, RefObject } from 'react';
 import { debounce as _debounce } from 'lodash';
 
 const DEBOUNCE_WAIT_TIME = 300;
@@ -8,15 +8,15 @@ type Dimension = {
   height: number;
 };
 
-interface useElementSizeOptions {
+type UseElementSizeOptions = {
   debounce?: boolean;
   enabled?: boolean;
-}
+};
 
 const useElementDimension = <T extends HTMLElement>({
   debounce,
   enabled = true,
-}: useElementSizeOptions = {}): {
+}: UseElementSizeOptions = {}): {
   ref: RefObject<T>;
   dimension: Dimension;
 } => {

--- a/src/shared/hooks/useVisualViewportDimension.ts
+++ b/src/shared/hooks/useVisualViewportDimension.ts
@@ -9,11 +9,10 @@ type Dimension = {
 };
 
 const useVisualViewportDimension = (enabled = true): Dimension => {
-  const initialDimension: Dimension = {
-    width: window.visualViewport.width,
-    height: window.visualViewport.height,
-  };
-  const [dimension, setDimension] = useState<Dimension>(initialDimension);
+  const [dimension, setDimension] = useState<Dimension>({
+    width: window?.visualViewport.width,
+    height: window?.visualViewport.height,
+  });
 
   useEffect(() => {
     if (!enabled || !window.visualViewport) return;

--- a/src/shared/hooks/useVisualViewportDimension.ts
+++ b/src/shared/hooks/useVisualViewportDimension.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { debounce } from 'lodash';
+
+const DEBOUNCE_WAIT_TIME = 300;
+
+type Dimension = {
+  width: number;
+  height: number;
+};
+
+const useVisualViewportDimension = (enabled = true): Dimension => {
+  const initialDimension: Dimension = {
+    width: window.visualViewport.width,
+    height: window.visualViewport.height,
+  };
+  const [dimension, setDimension] = useState<Dimension>(initialDimension);
+
+  useEffect(() => {
+    if (window.visualViewport && enabled) {
+      const resizeHandler = debounce(() => {
+        const { width, height } = window.visualViewport;
+        setDimension({ width, height });
+      }, DEBOUNCE_WAIT_TIME);
+
+      window.visualViewport.addEventListener('resize', resizeHandler);
+
+      return () => window.visualViewport.removeEventListener('resize', resizeHandler);
+    }
+  }, [enabled]);
+
+  return dimension;
+};
+
+export default useVisualViewportDimension;

--- a/src/shared/hooks/useVisualViewportDimension.ts
+++ b/src/shared/hooks/useVisualViewportDimension.ts
@@ -16,16 +16,16 @@ const useVisualViewportDimension = (enabled = true): Dimension => {
   const [dimension, setDimension] = useState<Dimension>(initialDimension);
 
   useEffect(() => {
-    if (window.visualViewport && enabled) {
-      const resizeHandler = debounce(() => {
-        const { width, height } = window.visualViewport;
-        setDimension({ width, height });
-      }, DEBOUNCE_WAIT_TIME);
+    if (!enabled || !window.visualViewport) return;
 
-      window.visualViewport.addEventListener('resize', resizeHandler);
+    const resizeHandler = debounce(() => {
+      const { width, height } = window.visualViewport;
+      setDimension({ width, height });
+    }, DEBOUNCE_WAIT_TIME);
 
-      return () => window.visualViewport.removeEventListener('resize', resizeHandler);
-    }
+    window.visualViewport.addEventListener('resize', resizeHandler);
+
+    return () => window.visualViewport.removeEventListener('resize', resizeHandler);
   }, [enabled]);
 
   return dimension;

--- a/src/shared/hooks/useVisualViewportDimension.ts
+++ b/src/shared/hooks/useVisualViewportDimension.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { debounce } from 'lodash';
+import { debounce } from 'lodash-es';
 
 const DEBOUNCE_WAIT_TIME = 300;
 

--- a/src/shared/styles/GlobalStyle.tsx
+++ b/src/shared/styles/GlobalStyle.tsx
@@ -22,8 +22,19 @@ const customReset = css`
   }
 
   body {
+    position: relative;
+    width: 100%;
+    overflow-y: auto;
     line-height: 1.5;
     -webkit-font-smoothing: antialiased;
+
+    > #make-scrollable {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 1px;
+      height: calc(100% + 1px); // height를 100%보다 1px높게 잡아 실제로 scroll이 되도록 만듭니다.
+    }
   }
 
   img,

--- a/src/shared/utils/getOS.ts
+++ b/src/shared/utils/getOS.ts
@@ -1,0 +1,17 @@
+type OS = 'web' | 'android' | 'ios';
+
+export const getOS = (): OS => {
+  if (typeof window === 'undefined') {
+    return 'web';
+  }
+
+  if (window.navigator.userAgent.match(/ipad|iphone/i) !== null) {
+    return 'ios';
+  }
+
+  if (window.navigator.userAgent.match(/Android/i) !== null) {
+    return 'android';
+  }
+
+  return 'web';
+};


### PR DESCRIPTION
## 📍 주요 변경사항

<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->


1. 공통 훅, util 함수 추가
- useElementDimension 훅: element 의 너비, 높이 반환
- useVisualViewportDimension 훅: visualViewport의 너비, 높이 반환
- getOS: 기기정보 반환 (web, ios, android 인지)

2. [채널톡 ios 15 대응기](https://channel.io/ko/blog/cross_browsing_ios15)를 참고해서 
(1) ios에서 document와 body에 이중으로 스크롤이 생기는문제
(2) 키보드 변경시 input이 아래로 내려가는 현상을 수정했습니다.

3. roomMemoForm의 높이가 변경됨에 따라 룸 리스트 하단을 가리는 문제가 있어서, 
useElementDimension 훅으로 roomMemoForm 높이를 알아내고 그 높이만큼 room list 하단에 padding을 주어 문제를 해결했습니다

 RoomMemoForm을 forwardRef으로 감싸고, 

## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

![Nov-26-2022 19-15-19](https://user-images.githubusercontent.com/39763891/204083652-a44a3c39-d05f-401f-b569-909f56585988.gif)

-> ios에서 헤더가 위로 올라가는 현상은 키보드 열렸을 때 해당 영역만큼 document를 밀기 때문인데요
키보드가 올라올떄 document를 밀어내지 않도록 네이티브 영역에서 설정할 수는 있지만, 
그렇게 한경우 input 위치를 상단에서 visualViewport만큼 떨어트린 위치로 조정해주어야하는데
visualViewport를 상태로 관리하기 때문에 위치를 조정할 때 딜레이가 발생합니다.
(목록이 길어지는 경우 올라간 인풋 아래로 목록이 보여 이상합니다)

![Nov-26-2022 19-21-19](https://user-images.githubusercontent.com/39763891/204083872-cebc00c8-3bdd-48ab-813b-a23056a14426.gif)

(또 이렇게 하기 위해서는 react-native WebView의 scrollEnabled 속성을 false로 지정해 주었는데,
이러면 그냥 웹뷰 스크롤이 안먹힙니다,, 화면을 밀어내지는 않으면서 스크롤을 가능하게 하는 방법은 못찾았네요..ㅎㅎ)




## 💡 중점적으로 봐주었으면 하는 부분

<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->
