### PR TITLE
feat: ✨ ChatContextMenu 컴포넌트 추가

### DIFF
--- a/src/features/chat/components/Chat/Chat.tsx
+++ b/src/features/chat/components/Chat/Chat.tsx
@@ -1,16 +1,10 @@
-import dayjs from 'dayjs';
-
 import { ChatProps } from './Chat.types';
 
 import { highlightenLink } from '@src/shared/utils/highlightenLink';
 import BaseChat from '@src/features/chat/components/Chat/components/BaseChat';
 import LinkBlock from '@src/features/chat/components/Chat/components/LinkBlock';
 
-const Chat = ({ type = 'TEXT', message, createdAt, link }: ChatProps) => {
-  const showContextMenu = () => {
-    // TODO : 우 클릭, long press 시 챗 옵션 모달 띄우기 (LinkBlock에서도 똑같이)
-  };
-
+const Chat = ({ type = 'TEXT', message, createdAt, link, onContextMenu }: ChatProps) => {
   if (type === 'PHOTO') {
     return <>TODO: photo chat</>;
   }
@@ -20,9 +14,9 @@ const Chat = ({ type = 'TEXT', message, createdAt, link }: ChatProps) => {
       <BaseChat
         message={type === 'LINK' ? highlightenLink(message) : message}
         createdAt={createdAt}
-        onContextMenu={showContextMenu}
+        onContextMenu={onContextMenu}
       />
-      {type === 'LINK' && link && <LinkBlock {...link} onContextMenu={showContextMenu} />}
+      {type === 'LINK' && link && <LinkBlock {...link} onContextMenu={onContextMenu} />}
     </>
   );
 };

--- a/src/features/chat/components/Chat/Chat.types.ts
+++ b/src/features/chat/components/Chat/Chat.types.ts
@@ -1,3 +1,5 @@
+import { MouseEvent } from 'react';
+
 import { ChatType } from '@src/shared/types/api/chat';
 
 export type ChatProps = {
@@ -12,4 +14,5 @@ export type ChatProps = {
     thumbnail?: string;
   };
   imageUrls?: string[];
+  onContextMenu?: (e?: MouseEvent<HTMLDivElement>) => void;
 };

--- a/src/features/chat/components/Chat/components/LinkBlock/LinkBlock.styles.ts
+++ b/src/features/chat/components/Chat/components/LinkBlock/LinkBlock.styles.ts
@@ -2,13 +2,12 @@ import styled from '@emotion/styled';
 
 import { ellipsis } from '@src/shared/styles';
 
-export const Wrapper = styled.a`
+export const Wrapper = styled.div`
   width: 80%;
   max-width: 262px;
   border-radius: 16px;
   margin-top: 6px;
   background-color: ${(p) => p.theme.color.white};
-  color: ${(p) => p.theme.color.black1};
   overflow: hidden;
 `;
 
@@ -36,10 +35,12 @@ export const Content = styled.div`
 export const Title = styled.span<{ hasDescription?: boolean }>`
   ${(p) => p.theme.typography.body2};
   ${(p) => ellipsis(p.hasDescription ? 1 : 2)}
+  color: ${(p) => p.theme.color.black1};
 `;
 
 export const Description = styled.span<{ hasTitle?: boolean }>`
   margin-top: 2px;
   ${(p) => p.theme.typography.body5};
   ${(p) => ellipsis(p.hasTitle ? 1 : 2)}
+  color: ${(p) => p.theme.color.black1};
 `;

--- a/src/features/chat/components/Chat/components/LinkBlock/LinkBlock.tsx
+++ b/src/features/chat/components/Chat/components/LinkBlock/LinkBlock.tsx
@@ -1,24 +1,19 @@
-import { MouseEvent } from 'react';
-
 import { LinkBlockProps } from './LinkBlock.types';
 import * as S from './LinkBlock.styles';
 
 const LinkBlock = ({ href, thumbnail, title, description, onContextMenu }: LinkBlockProps) => {
-  const handleContextMenu = (e: MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault();
-    onContextMenu?.(e);
-  };
-
   return (
-    <S.Wrapper href={href} onContextMenu={handleContextMenu}>
-      <S.ImageContainer>
-        <img src={thumbnail} alt="" width="100%" />
-      </S.ImageContainer>
-      <S.Content>
-        {!title && !description && <S.Title>-</S.Title>}
-        {title && <S.Title hasDescription={!!description}>{title}</S.Title>}
-        {description && <S.Description hasTitle={!!title}>{description}</S.Description>}
-      </S.Content>
+    <S.Wrapper onContextMenu={onContextMenu}>
+      <a href={href}>
+        <S.ImageContainer>
+          <img src={thumbnail} alt="" width="100%" />
+        </S.ImageContainer>
+        <S.Content>
+          {!title && !description && <S.Title>-</S.Title>}
+          {title && <S.Title hasDescription={!!description}>{title}</S.Title>}
+          {description && <S.Description hasTitle={!!title}>{description}</S.Description>}
+        </S.Content>
+      </a>
     </S.Wrapper>
   );
 };

--- a/src/features/chat/components/Chat/components/LinkBlock/LinkBlock.types.ts
+++ b/src/features/chat/components/Chat/components/LinkBlock/LinkBlock.types.ts
@@ -5,5 +5,5 @@ export interface LinkBlockProps {
   thumbnail?: string;
   title?: string;
   description?: string;
-  onContextMenu?: (e?: MouseEvent<HTMLAnchorElement>) => void;
+  onContextMenu?: (e?: MouseEvent<HTMLDivElement>) => void;
 }

--- a/src/features/chat/components/ChatContextMenu/ChatContextMenu.stories.tsx
+++ b/src/features/chat/components/ChatContextMenu/ChatContextMenu.stories.tsx
@@ -9,13 +9,21 @@ export default {
   component: ChatContextMenu,
 } as ComponentMeta<typeof ChatContextMenu>;
 
-export const Default: StoryFn<typeof ChatContextMenu> = () => {
+export const Default: StoryFn<typeof ChatContextMenu> = (args) => {
   const [isShow, setShow] = useState(false);
 
   return (
     <>
       <Button onClick={() => setShow(true)}>Show ChatContextMenu</Button>
-      <ChatContextMenu isShow={isShow} onClose={() => setShow(false)} top={0} left={0} />
+      <ChatContextMenu
+        isShow={isShow}
+        onClose={() => setShow(false)}
+        top={0}
+        left={0}
+        onEdit={() => alert('수정')}
+        onCopy={() => alert('복사')}
+        onDelete={() => alert('삭제')}
+      />
     </>
   );
 };

--- a/src/features/chat/components/ChatContextMenu/ChatContextMenu.stories.tsx
+++ b/src/features/chat/components/ChatContextMenu/ChatContextMenu.stories.tsx
@@ -1,0 +1,21 @@
+import { ComponentMeta, StoryFn } from '@storybook/react';
+import { useState } from 'react';
+
+import ChatContextMenu from '.';
+
+import { Button } from '@src/shared/components';
+
+export default {
+  component: ChatContextMenu,
+} as ComponentMeta<typeof ChatContextMenu>;
+
+export const Default: StoryFn<typeof ChatContextMenu> = () => {
+  const [isShow, setShow] = useState(false);
+
+  return (
+    <>
+      <Button onClick={() => setShow(true)}>Show ChatContextMenu</Button>
+      <ChatContextMenu isShow={isShow} onClose={() => setShow(false)} top={0} left={0} />
+    </>
+  );
+};

--- a/src/features/chat/components/ChatContextMenu/ChatContextMenu.styles.ts
+++ b/src/features/chat/components/ChatContextMenu/ChatContextMenu.styles.ts
@@ -1,0 +1,35 @@
+import styled from '@emotion/styled';
+
+export const Wrapper = styled.ul<{ top: number; left: number }>`
+  position: fixed;
+  top: ${(p) => p.top};
+  left: ${(p) => p.left};
+  width: 262px;
+  max-width: 60%;
+  border-radius: 8px;
+  overflow: hidden;
+  background-color: ${(p) => p.theme.color.white};
+  box-shadow: 0px 4px 30px rgba(51, 51, 51, 0.12);
+  z-index: ${(p) => p.theme.zIndex.modal};
+`;
+
+export const MenuItem = styled.li`
+  width: 100%;
+  ${(p) => p.theme.typography.body5};
+
+  > button {
+    width: 100%;
+    padding: 8px;
+    text-align: left;
+
+    &:hover,
+    &:active {
+      color: ${(p) => p.theme.color.white};
+      background-color: ${(p) => p.theme.color.purple1};
+    }
+  }
+
+  &:not(:last-child) {
+    border-bottom: 1px solid ${(p) => p.theme.color.gray6};
+  }
+`;

--- a/src/features/chat/components/ChatContextMenu/ChatContextMenu.tsx
+++ b/src/features/chat/components/ChatContextMenu/ChatContextMenu.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+
+import { ChatContextMenuProps } from './ChatContextMenu.types';
+import * as S from './ChatContextMenu.styles';
+
+const ChatContextMenu = ({
+  isShow,
+  top,
+  left,
+  onEdit,
+  onCopy,
+  onDelete,
+  onClose,
+}: ChatContextMenuProps) => {
+  const ref = useRef<HTMLUListElement>(null);
+
+  useEffect(() => {
+    if (isShow) {
+      ref.current.focus();
+    }
+  }, [isShow]);
+
+  const clickEdit = () => {
+    onEdit?.();
+    onClose();
+  };
+
+  const clickCopy = () => {
+    onCopy?.();
+    onClose();
+  };
+
+  const clickDelete = () => {
+    onDelete?.();
+    onClose();
+  };
+
+  if (!isShow) {
+    return null;
+  }
+
+  return createPortal(
+    <S.Wrapper ref={ref} tabIndex={-1} onBlur={onClose} top={top} left={left}>
+      {[
+        { label: '수정', onClick: clickEdit },
+        { label: '복사', onClick: clickCopy },
+        { label: '삭제', onClick: clickDelete },
+      ].map(({ label, onClick }) => (
+        <S.MenuItem key={label}>
+          <button type="button" onClick={onClick}>
+            {label}
+          </button>
+        </S.MenuItem>
+      ))}
+    </S.Wrapper>,
+    document.body,
+  );
+};
+
+export default ChatContextMenu;

--- a/src/features/chat/components/ChatContextMenu/ChatContextMenu.types.ts
+++ b/src/features/chat/components/ChatContextMenu/ChatContextMenu.types.ts
@@ -1,0 +1,9 @@
+export interface ChatContextMenuProps {
+  isShow: boolean;
+  top: number;
+  left: number;
+  onEdit: VoidFunction;
+  onCopy: VoidFunction;
+  onDelete: VoidFunction;
+  onClose: VoidFunction;
+}

--- a/src/features/chat/components/ChatContextMenu/index.ts
+++ b/src/features/chat/components/ChatContextMenu/index.ts
@@ -1,0 +1,2 @@
+export { default } from './ChatContextMenu';
+export type { ChatContextMenuProps } from './ChatContextMenu.types';


### PR DESCRIPTION
## 📍 주요 변경사항

<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

- ChatContextMenu 컴포넌트 추가
- LinkBlock 가장 바깥 요소 div로 변경
    - onContextMenu의 event 타입을 `MouseEvent<HTMLDivElement>`로 통일시키기 위함
    - a태그는 div바로 자식 요소로 남겨둠

## 🔗 참고자료

<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

## 💡 중점적으로 봐주었으면 하는 부분

<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->
