### PR TITLE
fix: :bug: ios contextMenu안열리는 현상 해결

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -48,6 +48,7 @@
         "unusedExports": true,
         "ignoreExports": ["./src/pages"]
       }
-    ]
+    ],
+    "@typescript-eslint/no-floating-promises": "error"
   }
 }

--- a/src/features/chat/components/Chat/Chat.tsx
+++ b/src/features/chat/components/Chat/Chat.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useContext } from 'react';
+import { useContext } from 'react';
 
 import BaseChat from '@src/features/chat/components/Chat/components/BaseChat';
 import LinkChat from '@src/features/chat/components/Chat/components/LinkChat/LinkChat';
@@ -6,7 +6,6 @@ import PhotoChat from '@src/features/chat/components/Chat/components/PhotoChat';
 import ChatContextMenuContext from '@src/features/chat/components/Chat/contexts/ChatContext';
 import { parseStringToDate } from '@src/shared/utils/date';
 import { highlightenLink } from '@src/shared/utils/highlightenLink';
-import { ChatType } from '@src/shared/types/chat';
 
 import * as S from './Chat.styles';
 import { ChatProps } from './Chat.types';
@@ -16,8 +15,8 @@ const Chat = (props: ChatProps) => {
   const { createdAt, message, type, link, title, description, thumbnail } = chat;
   const { renderContextMenu } = useContext(ChatContextMenuContext);
 
-  const handleOpenContextMenu = async (e: MouseEvent<HTMLDivElement>) => {
-    await renderContextMenu({ x: e.clientX, y: e.clientY }, chat);
+  const handleOpenContextMenu = async ({ x, y }: { x: number; y: number }) => {
+    await renderContextMenu({ x, y, chat });
   };
 
   if (type === 'PHOTO') {
@@ -39,7 +38,7 @@ const Chat = (props: ChatProps) => {
           <LinkChat
             message={highlightenLink(message)}
             createdAt={parseStringToDate(createdAt)}
-            onContextMenu={handleOpenContextMenu}
+            onOpenContextMenu={handleOpenContextMenu}
             link={{
               href: link,
               title: title,
@@ -53,7 +52,7 @@ const Chat = (props: ChatProps) => {
         <BaseChat
           message={message}
           createdAt={parseStringToDate(createdAt)}
-          onContextMenu={handleOpenContextMenu}
+          onOpenContextMenu={handleOpenContextMenu}
         />
       )}
     </S.Wrapper>

--- a/src/features/chat/components/Chat/components/BaseChat/BaseChat.tsx
+++ b/src/features/chat/components/Chat/components/BaseChat/BaseChat.tsx
@@ -1,17 +1,32 @@
 import dayjs from 'dayjs';
-import { MouseEvent } from 'react';
+import { TouchEvent, useEffect, useRef } from 'react';
 
-import { BaseChatProps } from './BaseChat.types';
 import * as S from './BaseChat.styles';
+import { BaseChatProps } from './BaseChat.types';
 
-const BaseChat = ({ message, createdAt, onContextMenu }: BaseChatProps) => {
-  const handleContextMenu = (e: MouseEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    onContextMenu?.(e);
+const BaseChat = ({ message, createdAt, onOpenContextMenu }: BaseChatProps) => {
+  const ref = useRef(null);
+  const handleContextMenu = async (e: TouchEvent<HTMLDivElement>) => {
+    const { clientX, clientY } = e.touches[0];
+    ref.current = setTimeout(() => {
+      onOpenContextMenu({ x: clientX, y: clientY });
+    }, 1000);
   };
 
+  useEffect(() => {
+    return () => {
+      ref.current = null;
+    };
+  }, []);
+
   return (
-    <S.Wrapper onContextMenu={handleContextMenu}>
+    <S.Wrapper
+      onContextMenu={(e) => e.preventDefault()}
+      onTouchStart={handleContextMenu}
+      onTouchEnd={() => {
+        clearTimeout(ref.current);
+      }}
+    >
       <S.Message>{message}</S.Message>
       <S.Date>{`${dayjs(createdAt).format('hh:mm A')}`}</S.Date>
     </S.Wrapper>

--- a/src/features/chat/components/Chat/components/BaseChat/BaseChat.types.ts
+++ b/src/features/chat/components/Chat/components/BaseChat/BaseChat.types.ts
@@ -1,7 +1,9 @@
-import { MouseEvent, ReactNode } from 'react';
+import { ReactNode } from 'react';
+
+import { Chat } from '@src/shared/types/chat';
 
 export interface BaseChatProps {
   message: ReactNode;
   createdAt: Date;
-  onContextMenu?: (e?: MouseEvent<HTMLDivElement>) => void;
+  onOpenContextMenu?: ({ x, y }: { x: number; y: number }) => void;
 }

--- a/src/features/chat/components/Chat/components/LinkBlock/LinkBlock.tsx
+++ b/src/features/chat/components/Chat/components/LinkBlock/LinkBlock.tsx
@@ -1,10 +1,10 @@
 import { LinkBlockProps } from './LinkBlock.types';
 import * as S from './LinkBlock.styles';
 
-const LinkBlock = ({ href, thumbnail, title, description, onClick }: LinkBlockProps) => {
+const LinkBlock = ({ href, thumbnail, title, description }: LinkBlockProps) => {
   return (
-    <S.Wrapper onClick={onClick}>
-      <a href={href}>
+    <S.Wrapper>
+      <a href={href} target="_blank" rel="noopener noreferrer">
         <S.ImageContainer>
           <img src={thumbnail} alt="" width="100%" />
         </S.ImageContainer>

--- a/src/features/chat/components/Chat/components/LinkBlock/LinkBlock.types.ts
+++ b/src/features/chat/components/Chat/components/LinkBlock/LinkBlock.types.ts
@@ -1,9 +1,6 @@
-import { MouseEvent } from 'react';
-
 export interface LinkBlockProps {
   href: string;
   thumbnail?: string;
   title?: string;
   description?: string;
-  onClick?: (e?: MouseEvent<HTMLDivElement>) => void;
 }

--- a/src/features/chat/components/Chat/components/LinkChat/LinkChat.tsx
+++ b/src/features/chat/components/Chat/components/LinkChat/LinkChat.tsx
@@ -3,20 +3,15 @@ import LinkBlock from '@src/features/chat/components/Chat/components/LinkBlock/L
 
 import { LinkChatProps } from './LinkChat.types';
 
-const LinkChat = ({ createdAt, message, onContextMenu, link }: LinkChatProps) => {
-  const handleGoUrl = () => {
-    //TODO: webview newWebview or 설치된 브라우저 열어주는 액션 필요함
-    window.open(link.href, '_blank');
-  };
+const LinkChat = ({ createdAt, message, onOpenContextMenu, link }: LinkChatProps) => {
   return (
     <>
-      <BaseChat message={message} createdAt={createdAt} onContextMenu={onContextMenu} />
+      <BaseChat message={message} createdAt={createdAt} onOpenContextMenu={onOpenContextMenu} />
       <LinkBlock
         title={link.title}
         description={link.description}
         thumbnail={link.thumbnail}
         href={link.href}
-        onClick={handleGoUrl}
       />
     </>
   );

--- a/src/features/chat/components/Chat/components/LinkChat/LinkChat.types.ts
+++ b/src/features/chat/components/Chat/components/LinkChat/LinkChat.types.ts
@@ -1,9 +1,11 @@
-import { MouseEvent, ReactNode } from 'react';
+import { ReactNode } from 'react';
+
+import { Chat } from '@src/shared/types/chat';
 
 export interface LinkChatProps {
   message: ReactNode;
   createdAt: Date;
-  onContextMenu?: (e?: MouseEvent<HTMLDivElement>) => void;
+  onOpenContextMenu?: ({ x, y }: { x: number; y: number }) => void;
   link: {
     href: string;
     title: string;

--- a/src/features/chat/components/Chat/contexts/ChatContext.tsx
+++ b/src/features/chat/components/Chat/contexts/ChatContext.tsx
@@ -5,7 +5,7 @@ import ChatContextMenu from '@src/features/chat/components/ChatContextMenu/ChatC
 import { Chat } from '@src/shared/types/chat';
 
 type ChatContextMenuContextType = {
-  renderContextMenu: ({ x, y }: { x: number; y: number }, chat: Chat) => Promise<boolean>;
+  renderContextMenu: ({ x, y, chat }: { x: number; y: number; chat: Chat }) => Promise<boolean>;
   closeContextMenu: () => void;
 };
 const ChatContextMenuContext = createContext<ChatContextMenuContextType>(null);
@@ -41,12 +41,13 @@ export const ChatContextMenuContextProvider: FC<{
   }, [handleClose]);
 
   const renderContextMenu = useCallback(
-    ({ x, y }: { x: number; y: number }, currentChat: Chat) => {
+    ({ x, y, chat }: { x: number; y: number; chat: Chat }) => {
       if (isOpen) {
         closeContextMenu();
+        return;
       }
 
-      setCurrentChat(currentChat);
+      setCurrentChat(chat);
       const menuWidth = 262;
 
       if (x + menuWidth > window.innerWidth) {

--- a/src/pages/rooms/[roomId]/chats/index.page.tsx
+++ b/src/pages/rooms/[roomId]/chats/index.page.tsx
@@ -1,19 +1,20 @@
 import { QueryClient, dehydrate } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 import { useEffect, useRef, useState } from 'react';
-import { VirtuosoHandle } from 'react-virtuoso';
 import { useCopyToClipboard } from 'react-use';
-import { SubmitHandler } from 'react-hook-form';
+import { VirtuosoHandle } from 'react-virtuoso';
 
 import AuthGuard from '@src/features/auth/components/AuthGuard';
 import { useChatsInfiniteQuery } from '@src/features/chat/api/useChatsInfiniteQuery';
 import useCreateChatMutation from '@src/features/chat/api/useCreateChatMutation';
 import useDeleteChatMutation from '@src/features/chat/api/useDeleteChatMutation';
+import useUpdateChatMutation from '@src/features/chat/api/useUpdateChatMutation';
 import { ChatContextMenuContextProvider } from '@src/features/chat/components/Chat/contexts/ChatContext';
 import ChatList from '@src/features/chat/components/ChatList';
 import ChatListEmpty from '@src/features/chat/components/ChatListEmpty';
 import useRoomQuery from '@src/features/room/api/useRoomQuery';
 import { RoomMemoForm } from '@src/features/room/components';
+import RoomMemoEditForm from '@src/features/room/components/RoomMemoEditForm/RoomMemoEditForm';
 import { Header, Icon } from '@src/shared/components';
 import { setServerSideCookies } from '@src/shared/configs/axios';
 import useConfirm from '@src/shared/hooks/useConfirm';
@@ -21,8 +22,6 @@ import useElementDimension from '@src/shared/hooks/useDimension';
 import { Chat } from '@src/shared/types/chat';
 import { GetServerSidePropsWithState, NextPageWithLayout } from '@src/shared/types/next';
 import { toast } from '@src/shared/utils/toast';
-import RoomMemoEditForm from '@src/features/room/components/RoomMemoEditForm/RoomMemoEditForm';
-import useUpdateChatMutation from '@src/features/chat/api/useUpdateChatMutation';
 
 import * as S from './chats.styles';
 
@@ -124,7 +123,7 @@ const ChatListPage: NextPageWithLayout<ChatListProps> = ({ roomId }) => {
   };
 
   const handleGoSetting = () => {
-    router.push(`/rooms/${roomId}/setting`);
+    void router.push(`/rooms/${roomId}/setting`);
   };
 
   useEffect(() => {
@@ -132,7 +131,7 @@ const ChatListPage: NextPageWithLayout<ChatListProps> = ({ roomId }) => {
       return;
     }
 
-    router.prefetch(`/rooms/${roomId}/setting`);
+    void router.prefetch(`/rooms/${roomId}/setting`);
   }, [roomId, router]);
 
   return (

--- a/src/shared/utils/highlightenLink.tsx
+++ b/src/shared/utils/highlightenLink.tsx
@@ -11,7 +11,13 @@ export const highlightenLink = (text: string): ReactNode => {
         return (
           <>
             {acc}
-            {type === 'link' ? <a href={content}>{content}</a> : content}
+            {type === 'link' ? (
+              <a href={content} target="_blank" rel="noopener noreferrer">
+                {content}
+              </a>
+            ) : (
+              content
+            )}
           </>
         );
       }, <></>);


### PR DESCRIPTION
## 📍 주요 변경사항

iosContextMenu안열리는 현상을 해결했습니다.
-  기존에 contextMenu이벤트를 받아서 contextmenu를 열어줬는데 ios에서는 touch 이벤트가 mouseEvent로 동작되지 않아서 이 onContextMenu가 호출되지 않았었습니다

### 해결방법
touchStart 리스너에 setTimeout을 걸어줘서 일정 시간이 지나면 contextmenu가 열리도록 구현, touchEnd 리스너에 clearTimeOut을 걸어줘서 일정시간동안 사용자가 터치를 누르지 않고 있으면 타임아웃 클러

사용자가 버튼을 누르고 있는 시간 > 일정시간(1000ms) 인 경우 contextMenu  열기
그 외 touchEnd리스너에서 clearTimeout


